### PR TITLE
change pointer for publishing container to GCP AR

### DIFF
--- a/iac/main.tf
+++ b/iac/main.tf
@@ -3,7 +3,7 @@
 
 provider "google" { project = var.project_id }
 provider "google-beta" { project = var.project_id }
-provider "ko" { repo = "gcr.io/${var.project_id}" }
+provider "ko" { repo = "us-docker.pkg.dev/sigstore-support-tooling/${var.project_id}" }
 
 // Create a network with several regional subnets
 module "networking" {


### PR DESCRIPTION
`gcr.io/sigstore-support-tooling` => `us-docker.pkg.dev/sigstore-support-tooling/sigstore-support-tooling`